### PR TITLE
Implemented #285 quick assist convert then/else to if/else

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/parse/CeylonSourcePositionLocator.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/parse/CeylonSourcePositionLocator.java
@@ -30,10 +30,12 @@ import com.redhat.ceylon.compiler.typechecker.io.impl.ZipFileVirtualFile;
 import com.redhat.ceylon.compiler.typechecker.model.Unit;
 import com.redhat.ceylon.compiler.typechecker.tree.Node;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.Statement;
 import com.redhat.ceylon.eclipse.code.editor.CeylonEditor;
 import com.redhat.ceylon.eclipse.code.editor.Util;
 import com.redhat.ceylon.eclipse.core.vfs.IFileVirtualFile;
 import com.redhat.ceylon.eclipse.ui.CeylonPlugin;
+import com.redhat.ceylon.eclipse.util.FindStatementVisitor;
 
 /**
  * NOTE:  This version of the ISourcePositionLocator is for use when the Source
@@ -79,6 +81,13 @@ public class CeylonSourcePositionLocator implements ISourcePositionLocator {
         cu.visit(visitor);
         return visitor.getNode();
     }
+
+    public static Statement findStatement(Tree.CompilationUnit cu, Node node) {
+        FindStatementVisitor visitor = new FindStatementVisitor(node, false);
+        cu.visit(visitor);
+        return visitor.getStatement();
+    }
+
     
     public static Node findScope(Tree.CompilationUnit cu, int startOffset, int endOffset) {
         FindScopeVisitor visitor = new FindScopeVisitor(startOffset, endOffset);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/CeylonQuickFixAssistant.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/CeylonQuickFixAssistant.java
@@ -8,7 +8,7 @@ import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.CORRECT
 import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.INTERFACE;
 import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.METHOD;
 import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.PARAMETER;
-import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.findNode;
+import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.*;
 import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.getIdentifyingNode;
 import static com.redhat.ceylon.eclipse.code.propose.CeylonContentProposer.getProposals;
 import static com.redhat.ceylon.eclipse.code.propose.CeylonContentProposer.getRefinementTextFor;
@@ -75,6 +75,7 @@ import com.redhat.ceylon.compiler.typechecker.tree.Tree.Primary;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Return;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifiedArgument;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifierExpression;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.Statement;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Type;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.TypedArgument;
 import com.redhat.ceylon.compiler.typechecker.tree.Visitor;
@@ -199,9 +200,11 @@ public class CeylonQuickFixAssistant implements IQuickFixAssistant {
                 AddParameterProposal.addParameterProposal(doc, cu, proposals, 
                         file, dec, editor);
             }
-            ConvertThenElseToIfElse.addConvertToGetterProposal(doc, proposals, file, node);
             CreateObjectProposal.addCreateObjectProposal(doc, cu, proposals, file, node);
             CreateLocalSubtypeProposal.addCreateLocalSubtypeProposal(doc, cu, proposals, file, node);
+
+            Statement statement = findStatement(cu, node);
+            ConvertThenElseToIfElse.addConvertToGetterProposal(doc, proposals, file, statement);
         }
 
         CreateSubtypeProposal.add(proposals, editor);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/ConvertThenElseToIfElse.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/ConvertThenElseToIfElse.java
@@ -1,30 +1,30 @@
 package com.redhat.ceylon.eclipse.code.quickfix;
 
-import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.CORRECTION;
+import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.CHANGE;
 
 import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.imp.editor.quickfix.ChangeCorrectionProposal;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.text.correction.proposals.EditAnnotator;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ltk.core.refactoring.DocumentChange;
 import org.eclipse.ltk.core.refactoring.TextChange;
-import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
-
-import antlr.Token;
+import org.eclipse.text.edits.TextEdit;
 
 import com.redhat.ceylon.compiler.typechecker.tree.CustomTree;
 import com.redhat.ceylon.compiler.typechecker.tree.Node;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree;
-import com.redhat.ceylon.compiler.typechecker.tree.Tree.AssignOp;
-import com.redhat.ceylon.compiler.typechecker.tree.Tree.InitializerExpression;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Return;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifierExpression;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifierOrInitializerExpression;
-import com.redhat.ceylon.compiler.typechecker.tree.Tree.Term;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.Statement;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.ThenOp;
 import com.redhat.ceylon.eclipse.code.editor.CeylonAutoEditStrategy;
 import com.redhat.ceylon.eclipse.code.editor.Util;
@@ -35,7 +35,7 @@ class ConvertThenElseToIfElse extends ChangeCorrectionProposal {
     final IFile file;
     
     ConvertThenElseToIfElse(int offset, IFile file, TextChange change) {
-        super("Convert expression to If/Else", change, 10, CORRECTION);
+        super("Convert to if-else", change, 10, CHANGE);
         this.offset=offset;
         this.file=file;
     }
@@ -48,38 +48,49 @@ class ConvertThenElseToIfElse extends ChangeCorrectionProposal {
     
     static void addConvertToGetterProposal(IDocument doc,
     			Collection<ICompletionProposal> proposals, IFile file,
-    			Node node) {
+    			Statement statement) {
     	try {
     		String action;
-    		String prefix = null;
+    		String declaration = null;
     		Node operation;
-    		if (node instanceof Tree.Return) {
-    			Tree.Return returnOp = (Return) node;
+    		if (statement instanceof Tree.Return) {
+    			Tree.Return returnOp = (Return) statement;
     			action = "return ";
-    			if (returnOp.getExpression() == null) {
+    			if (returnOp.getExpression() == null || returnOp.getExpression().getTerm() == null) {
     				return;
     			}
     			operation = returnOp.getExpression().getTerm();
     			
-    		} else if (node instanceof Tree.AssignOp) {
-    			Tree.AssignOp assignOp = (AssignOp) node;
+    		} else if (statement instanceof Tree.ExpressionStatement) {
+    			Tree.ExpressionStatement expressionStmt = (Tree.ExpressionStatement) statement;
+    			if (expressionStmt.getExpression() == null) {
+    				return;
+    			}
+    			Tree.Expression expression = expressionStmt.getExpression();
+    			if (expression.getChildren().isEmpty()) {
+    				return;
+    			}
+    			if (! (expression.getChildren().get(0) instanceof Tree.AssignOp)) {
+    				return;
+    			}
+				Tree.AssignOp assignOp = (Tree.AssignOp) expression.getChildren().get(0);
     			action = getTerm(doc, assignOp.getLeftTerm()) + " := ";
     			operation = assignOp.getRightTerm();
-    		} else if (node instanceof CustomTree.AttributeDeclaration) {
-    			CustomTree.AttributeDeclaration attrDecl = (CustomTree.AttributeDeclaration) node;
+    		} else if (statement instanceof CustomTree.AttributeDeclaration) {
+    			CustomTree.AttributeDeclaration attrDecl = (CustomTree.AttributeDeclaration) statement;
     			String identifier = getTerm(doc, attrDecl.getIdentifier());
 				String annotations = "";
 				if (!attrDecl.getAnnotationList().getAnnotations().isEmpty()) {
 					annotations = getTerm(doc, attrDecl.getAnnotationList()) + " ";
 				}
-				prefix = annotations + getTerm(doc, attrDecl.getType()) + " " + identifier + ";";
+				declaration = annotations + getTerm(doc, attrDecl.getType()) + " " + identifier + ";";
     			action = identifier + " " + getToken(attrDecl.getSpecifierOrInitializerExpression()) + " ";
     			operation = attrDecl.getSpecifierOrInitializerExpression().getExpression().getTerm();
     		} else {
     			return;
     		}
     		
-    		String ifExpression;
+    		String test;
     		String elseTerm;
     		String thenTerm;
 			
@@ -88,58 +99,45 @@ class ConvertThenElseToIfElse extends ChangeCorrectionProposal {
     			if (defaultOp.getLeftTerm() instanceof Tree.ThenOp) {
     				Tree.ThenOp thenOp = (ThenOp) defaultOp.getLeftTerm();
     				thenTerm = getTerm(doc, thenOp.getRightTerm());
-    				ifExpression = getTerm(doc, thenOp.getLeftTerm());
+    				test = getTerm(doc, thenOp.getLeftTerm());
     			} else {
     				thenTerm = getTerm(doc, defaultOp.getLeftTerm());
-    				ifExpression = "exists " + thenTerm;
+    				test = "exists " + thenTerm;
     			}
     			elseTerm = getTerm(doc, defaultOp.getRightTerm());
     		} else if (operation instanceof Tree.ThenOp) {
     			Tree.ThenOp thenOp = (ThenOp) operation;
     			thenTerm = getTerm(doc, thenOp.getRightTerm());
-   			 	ifExpression = getTerm(doc, thenOp.getLeftTerm());
+   			 	test = getTerm(doc, thenOp.getLeftTerm());
    			 	elseTerm = "null";
     		} else {
     			return;
     		}
 
-			// return test then x else y;
-			// return test then x;
-			// return obj else default;
-			// Object o = test then x else y;
-			// Object o = test else default;
-			// Object o = x else default;
-
-			String baseIndent = CeylonQuickFixAssistant.getIndent(node, doc);
-			String test;
-			test = removeEnclosingParentesis(ifExpression);
-			String then = thenTerm;
-			String else_ = elseTerm;
-			StringBuilder replace = buildIfElse(baseIndent, prefix, test, action, then,else_);
-
-			TextChange change = new DocumentChange("Convert To Getter", doc);
-			change.setEdit(new MultiTextEdit());
-			int length;
-			int stopIndex;
-			if (doc.getChar(node.getStopIndex()) == ';') {
-				stopIndex = node.getStopIndex();
-			} else { //Workaround since the AssignOp length does not include the semi-colon 
-				stopIndex = node.getStopIndex() + 1;
-				while (stopIndex < doc.getLength() && (doc.getChar(stopIndex)) != ';') {
-					if (! isWhitespace(doc.getChar(stopIndex))) {
-						return; //
-					}
-					stopIndex++;
-				}
+			String baseIndent = CeylonQuickFixAssistant.getIndent(statement, doc);
+			String indent = CeylonAutoEditStrategy.getDefaultIndent();
+			
+			test = removeEnclosingParentesis(test);
+			
+			StringBuilder replace = new StringBuilder();
+			if (declaration != null) {
+				replace.append(declaration).append("\n").append(baseIndent);
 			}
-			length = stopIndex - node.getStartIndex() + 1;
-			change.addEdit(new ReplaceEdit(node.getStartIndex(), length, replace.toString()));
-			proposals.add(new ConvertThenElseToIfElse(node.getStartIndex(), file, change));
+			replace.append("if (").append(test).append(") {\n")
+					.append(baseIndent).append(indent).append(action).append(thenTerm).append(";\n")
+					.append(baseIndent).append("}\n")
+					.append(baseIndent).append("else {\n")
+					.append(baseIndent).append(indent).append(action).append(elseTerm).append(";\n")
+					.append(baseIndent).append("}");
+
+			TextChange change = new DocumentChange("Convert To if-else", doc);
+			change.setEdit(new ReplaceEdit(statement.getStartIndex(), statement.getStopIndex() - statement.getStartIndex() + 1, replace.toString()));
+			proposals.add(new ConvertThenElseToIfElse(statement.getStartIndex(), file, change));
 		} catch (BadLocationException e) {
 			e.printStackTrace();
 		}
     }
-
+    
 	private static String getToken(
 			SpecifierOrInitializerExpression token) {
 		if (token instanceof SpecifierExpression) {
@@ -149,21 +147,7 @@ class ConvertThenElseToIfElse extends ChangeCorrectionProposal {
 		}
 	}
 
-	private static StringBuilder buildIfElse(String baseIndent, String prefix, String test,
-			String action, String then, String else_) {
-		String indent = CeylonAutoEditStrategy.getDefaultIndent();
-		StringBuilder replace = new StringBuilder();
-		replace.append(prefix != null ? prefix + "\n" + baseIndent : "")
-				.append("if (").append(test).append(") {\n")
-				.append(baseIndent).append(indent).append(action).append(then).append(";\n")
-				.append(baseIndent).append("}\n")
-				.append(baseIndent).append("else {\n")
-				.append(baseIndent).append(indent).append(action).append(else_).append(";\n")
-				.append(baseIndent).append("}");
-		return replace;
-	}
-    
-    private static String removeEnclosingParentesis(String s) {
+	private static String removeEnclosingParentesis(String s) {
     	if (s.charAt(0) == '(' && s.charAt(s.length() - 1) == ')') {
     		return s.substring(1, s.length() - 1);
     	}
@@ -173,10 +157,4 @@ class ConvertThenElseToIfElse extends ChangeCorrectionProposal {
     private static String getTerm(IDocument doc, Node node) throws BadLocationException {
     	return doc.get(node.getStartIndex(), node.getStopIndex() - node.getStartIndex() + 1);
     }
-    
-    private static boolean isWhitespace(char c) {
-    	return (c == ' ' || c == '\t' || c == '\n' || c == '\r');
-    }
-      
-   
 }


### PR DESCRIPTION
Implemented #285 quick assist convert then/else to if/else

It works on all the then/else statements in this function:

```
String? hi() {
    Integer i = 1;
    Boolean test = true;
    String x = "x";
    String y = "y";
    String? obj = null;
    String default = "";

    if (i == 0) {
        return test then x else y;
    } else if (i == 1) {
        return test then x;
    } else if (i == 2) {
        return obj else default;
    }

    Object o = test then x else y;
    Object? o1 = test then default;
    Object o2 = obj else default;

    variable Object v := test then x else y;
    variable Object? v1 := test then default;
    variable Object v2 := obj else default;

    v := test then x else y;
    v1 := test then default;
    v2 := obj else default;

    return null;
}
```
