### PR TITLE
Improved #285 with inferred type for value modifier and running expressions only once

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/CeylonQuickFixAssistant.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/CeylonQuickFixAssistant.java
@@ -8,7 +8,8 @@ import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.CORRECT
 import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.INTERFACE;
 import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.METHOD;
 import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.PARAMETER;
-import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.*;
+import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.findNode;
+import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.findStatement;
 import static com.redhat.ceylon.eclipse.code.parse.CeylonSourcePositionLocator.getIdentifyingNode;
 import static com.redhat.ceylon.eclipse.code.propose.CeylonContentProposer.getProposals;
 import static com.redhat.ceylon.eclipse.code.propose.CeylonContentProposer.getRefinementTextFor;
@@ -72,7 +73,6 @@ import com.redhat.ceylon.compiler.typechecker.tree.Tree.ImportMemberOrType;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.ImportMemberOrTypeList;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.ParameterList;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Primary;
-import com.redhat.ceylon.compiler.typechecker.tree.Tree.Return;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifiedArgument;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifierExpression;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Statement;

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/ConvertThenElseToIfElse.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/quickfix/ConvertThenElseToIfElse.java
@@ -5,19 +5,13 @@ import static com.redhat.ceylon.eclipse.code.outline.CeylonLabelProvider.CHANGE;
 import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.imp.editor.quickfix.ChangeCorrectionProposal;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.EditAnnotator;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ltk.core.refactoring.DocumentChange;
 import org.eclipse.ltk.core.refactoring.TextChange;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.text.edits.ReplaceEdit;
-import org.eclipse.text.edits.TextEdit;
 
 import com.redhat.ceylon.compiler.typechecker.model.ProducedType;
 import com.redhat.ceylon.compiler.typechecker.tree.CustomTree;
@@ -31,7 +25,6 @@ import com.redhat.ceylon.compiler.typechecker.tree.Tree.SpecifierOrInitializerEx
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Statement;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.Term;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.ThenOp;
-import com.redhat.ceylon.compiler.typechecker.tree.Tree.Type;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree.ValueModifier;
 import com.redhat.ceylon.eclipse.code.editor.CeylonAutoEditStrategy;
 import com.redhat.ceylon.eclipse.code.editor.Util;


### PR DESCRIPTION
Improved issue #285 with type inference for value modifier and running expressions only once:

```
String? hi() {
    Integer i = 1;
    Boolean test = true;
    String x = "x";
    String y = "y";
    String? obj = null;
    String default = "";
    Process process = Process();
    //String first = "f";

    if (i == 0) {
        return test then x else y;
    } else if (i == 1) {
        return test then x;
    } else if (i == 2) {
        return obj else default;
    } else if (i == 3) {
        return process.first() else default;
    }

    Object o = test then x else y;
    Object? o1 = test then default;
    Object o2 = obj else default;
    Object o3 = process.first() else default;

    value o4= test then x else y;
    value o5 = test then default;
    value o6 = obj else default;
    value o7 = process.first() else default;


    variable Object v := test then x else y;
    variable Object? v1 := test then default;
    variable Object v2 := obj else default;
    variable Object v3 := process.first() else default;

    variable value v4 := test then x else y;
    variable value v5 := test then default;
    variable value v6 := obj else default;
    variable value v7 := process.first() else default;

    v := test then x else y;
    v1 := test then default;
    v2 := obj else default;
    v3 := process.first() else default;
    v4 := obj else default;

    return null;
}

class Process() {
    shared String? first() {
        return "first";
    }
}
```

Notice that if you un-comment the "first" attribute, the converted code from the process.first() expressions won't work since I re-use the name of the method name..
We should possibly improve this by triggering a rename in file action thing like they have in the Eclipse for Java. 
