### PR TITLE
fix for blank page in windows environment

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/DocHover.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/DocHover.java
@@ -445,6 +445,13 @@ public class DocHover
 			@Override
 			public void changing(LocationEvent event) {
 				String location = event.location;
+				
+				//This was necessary for windows environment (fix for blank page)
+				//Its someway related to this: https://bugs.eclipse.org/bugs/show_bug.cgi?id=129236
+				if (!"about:blank".equals(location)) { //$NON-NLS-1$
+					event.doit= false;
+				}
+				
 				if (location.startsWith("dec:")) {
 					Object target = getModel(control, location);
 					if (target!=null) {


### PR DESCRIPTION
At windows with eclipse kepler doing any click to navigate between elements in hover dialog generates a blank page, this code fix this issue.
