### PR TITLE
Fix #888

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/model/JDTModelLoader.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/model/JDTModelLoader.java
@@ -678,6 +678,9 @@ public class JDTModelLoader extends AbstractModelLoader {
     }
     
     private Unit newCompiledUnit(LazyPackage pkg, ClassMirror classMirror) {
+        if (classMirror == null) {
+            return null;
+        }
         Unit unit;
         JDTClass jdtClass = (JDTClass) classMirror;
         ITypeRoot typeRoot = null;


### PR DESCRIPTION
Fix #888 by returning immediately if `classMirror` is null.

**_DO NOT MERGE WITHOUT REVIEW.**_ I simply made the exception go away, but I don’t know enough about the inner workings of the IDE to decide if that actually fixes the problem. There are no more errors in the error log, but maybe that’s just because the `null` is detected elsewhere and the build is shut down properly?
