### PR TITLE
quick fix create object/class : solve exception with union types, plus enable quick fix for optional types

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ObjectClassDefinitionGenerator.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ObjectClassDefinitionGenerator.java
@@ -261,9 +261,14 @@ class ObjectClassDefinitionGenerator extends DefinitionGenerator {
         StringBuilder params = new StringBuilder();
         LinkedHashMap<String, ProducedType> paramTypes = getParameters(fav);
         if (returnType!=null) {
+            if(unit.isOptionalType(returnType)){
+                returnType = returnType.eliminateNull();
+            }
             TypeDeclaration rtd = returnType.getDeclaration();
-            if (rtd.equals(unit.getObjectDeclaration()) ||
-                    rtd.equals(unit.getAnythingDeclaration())) {
+            if ( (rtd instanceof Class) && (
+                    rtd.equals(unit.getObjectDeclaration()) || 
+                    rtd.equals(unit.getAnythingDeclaration()))
+            ) {
                 returnType = null;
             }
         }


### PR DESCRIPTION
Without this fix,
this code :

``` ceylon
class Foo2(){
}

class Foo(){
   void func(Foo2? n){
   }

   void bar(){
    func(baz); // baz does not exist
   }
}
```

causes this :

```
java.lang.UnsupportedOperationException: union types don't have well-defined equality
    at com.redhat.ceylon.compiler.typechecker.model.UnionType.equals(UnionType.java:81)
    at com.redhat.ceylon.eclipse.code.correct.ObjectClassDefinitionGenerator.create(ObjectClassDefinitionGenerator.java:265)
    at com.redhat.ceylon.eclipse.code.correct.CreateProposal.addCreateProposals(CreateProposal.java:252)
    at com.redhat.ceylon.eclipse.code.correct.CeylonCorrectionProcessor.addCreationProposals(CeylonCorrectionProcessor.java:794)
    at com.redhat.ceylon.eclipse.code.correct.CeylonCorrectionProcessor.addProposals(CeylonCorrectionProcessor.java:372)
```

This pull request also enables the quick fix create object/class for optional types. The exception is not thrown and the quick fix can be applied :

``` ceylon
class Foo2(){
}

class Foo(){
   void func(Foo2? n){
   }

   shared object baz 
         extends Foo2() {
   }
   void bar(){
    func(baz); 
   }
}

```
