### PR TITLE
improve default values for nullable ref in quick fix

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CorrectionUtil.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CorrectionUtil.java
@@ -132,12 +132,13 @@ public class CorrectionUtil {
 	    if (isTypeUnknown(t)) {
 	        return "nothing";
 	    }
-	    TypeDeclaration tn = t.getDeclaration();
-	    boolean isClass = tn instanceof Class;
-	    if (unit.isOptionalType(t)) {
-	        return "null";
-	    }
-	    else if (isClass &&
+        final boolean isOptional = unit.isOptionalType(t);
+        if (isOptional) {
+           t = t.eliminateNull();
+        }
+        final TypeDeclaration tn = t.getDeclaration();
+        final boolean isClass = tn instanceof Class;
+	    if (isClass &&
 	            tn.equals(unit.getBooleanDeclaration())) {
 	        return "false";
 	    }
@@ -188,7 +189,7 @@ public class CorrectionUtil {
             return sb.toString();
         }
         else {
-            return "nothing";
+            return isOptional ? "null" : "nothing";
         }
     }
     


### PR DESCRIPTION
Currently , for quick fix _create value_, when a ref is nullables, the default value is always `null`

With this pull request non-nullable and nullable values are on a par.
For instance the default value for `Boolean?` is `false`, instead of `null`

However, if a default value can not be computed, if the value is optional, `null` is still used instead of `nothing`.
For instance, the default value of `Integer|String?` is `null` (the default value of `Integer|String` is still `nothing`)
