### PR TITLE
fix npe during copy package between two projects

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/refactor/CopyPackageRefactoringParticipant.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/refactor/CopyPackageRefactoringParticipant.java
@@ -64,7 +64,7 @@ public class CopyPackageRefactoringParticipant extends CopyParticipant {
                 IPackageFragmentRoot dest = (IPackageFragmentRoot) getArguments().getDestination();
                 ReorgExecutionLog executionLog = getArguments().getExecutionLog();
                 final String newName = executionLog.getNewName(javaPackageFragment);
-                if (newName.isEmpty()) return null;
+                if (newName == null || newName.isEmpty()) return null;
                 newPackage = dest.getPackageFragment(newName).getResource();
                 final String oldName = javaPackageFragment.getElementName();
                 final IProject project = javaPackageFragment.getJavaProject().getProject();


### PR DESCRIPTION
This happens when a package is copied (via the explorer) between two Ceylon projects 
