### PR TITLE
fix ClassCastException for New > Module/Package/File on Module node

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/wizard/NewUnitWizardPage.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/wizard/NewUnitWizardPage.java
@@ -47,6 +47,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.wizards.IWizardDescriptor;
 
+import com.redhat.ceylon.eclipse.code.navigator.SourceModuleNode;
 import com.redhat.ceylon.eclipse.code.select.PackageSelectionDialog;
 import com.redhat.ceylon.eclipse.ui.CeylonPlugin;
 import com.redhat.ceylon.eclipse.util.Escaping;
@@ -76,6 +77,10 @@ class NewUnitWizardPage extends WizardPage {
             Object element = selection.getFirstElement();
             if (element instanceof IFile) {
                 return JavaCore.create(((IFile) element).getParent());
+            }
+            else if (element instanceof SourceModuleNode) {
+                return ((SourceModuleNode) element)
+                        .getMainPackageFragment();
             }
             else {
                 return (IJavaElement) ((IAdaptable) element)


### PR DESCRIPTION
OK, I'm not sure this is the right way to fix this, because this pull request may infringe upon https://github.com/ceylon/ceylon-ide-eclipse/issues/971

That being said, this is the problem : 
On a Module Node, New > Module / Package / Source File causes :

```
ava.lang.ClassCastException: com.redhat.ceylon.eclipse.code.navigator.SourceModuleNode cannot be cast to org.eclipse.core.runtime.IAdaptable
    at com.redhat.ceylon.eclipse.code.wizard.NewUnitWizardPage.getSelectedElement(NewUnitWizardPage.java:81)
    at com.redhat.ceylon.eclipse.code.wizard.NewUnitWizardPage.initFromSelection(NewUnitWizardPage.java:555)
    at com.redhat.ceylon.eclipse.code.wizard.NewUnitWizardPage.createControl(NewUnitWizardPage.java:94)
    at org.eclipse.jface.wizard.Wizard.createPageControls(Wizard.java:174)
    at org.eclipse.jface.wizard.WizardDialog.createPageControls(WizardDialog.java:736)
```
