### PR TITLE
fix #1019

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/imports/CleanImportsHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/imports/CleanImportsHandler.java
@@ -402,7 +402,9 @@ public class CleanImportsHandler extends AbstractHandler {
                 editor.getEditorInput() instanceof IFileEditorInput) {
             CeylonParseController cpc = 
                     ((CeylonEditor) editor).getParseController();
-            return cpc==null || cpc.getRootNode()==null ? false : true;
+            return cpc==null || 
+                      cpc.getRootNode()==null || 
+                      !cpc.getRootNode().getLiteralsProcessed() ? false : true;
                 //!cpc.getRootNode().getImportList().getImports().isEmpty();
         }
         else {


### PR DESCRIPTION
Fix https://github.com/ceylon/ceylon-ide-eclipse/issues/1019, I believe.

I'm playing the sorcerer's apprentice here, with `CompilationUnits#getLiteralsProcessed`, but it really improves the behavior of clean-import during intermediate build phases. I let you guys check if it makes sense.
