### PR TITLE
Fix compilation after ceylon/ceylon-sdk@bfbda4a

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/FormatAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/FormatAction.java
@@ -246,5 +246,10 @@ final class FormatAction extends Action {
         public String writeLine$line() {
             return ""; // default value for "line" parameter
         }
+        @Override
+        public Object writeBytes(ceylon.language.Iterable<? extends ceylon.language.Byte,? extends Object> bytes) {
+            // unused; ceylon.formatter never writes bytes
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
`ceylon.file.Writer` now has a `writeBytes({Byte*} bytes)` method that we need to supply.

Can @gavinking or perhaps @davidfestal please test if this works? I’m getting another error – something “refers to the missing type `Image` – but that might be due to a messed up local setup.

See ceylon/ceylon-sdk@bfbda4af9232feabca14faadf40b8b8d07e96e57, ceylon/ceylon.formatter@17c825014b31b797d1c2df21924d4605a64dcf11.
