### PR TITLE
recurse alias def to find default value in quick fix

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CorrectionUtil.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CorrectionUtil.java
@@ -133,6 +133,9 @@ public class CorrectionUtil {
             return "nothing";
         }
         TypeDeclaration tn = t.getDeclaration();
+        if(tn.isAlias()){
+            return defaultValue(unit, tn.getExtendedType());
+        }
         boolean isClass = tn instanceof Class;
         if (unit.isOptionalType(t)) {
             return "null";


### PR DESCRIPTION
use the real default value for an alias type, instead of `nothing`

i.e :

``` ceylon
alias Location => Float[2];
void foo(Location location){
    defaultValue = location;
}
```

now gives

``` ceylon
variable Location defaultValue = [0.0, 0.0];
```

FTR : it also works for recursive alias defintion
