### PR TITLE
fix ZipException

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/builder/CeylonBuilder.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/builder/CeylonBuilder.java
@@ -41,6 +41,7 @@ import javax.tools.JavaFileObject;
 
 import net.lingala.zip4j.core.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
 
 import org.antlr.runtime.CommonToken;
 import org.antlr.runtime.CommonTokenStream;
@@ -3229,7 +3230,11 @@ public class CeylonBuilder extends IncrementalProjectBuilder {
                 if(moduleSrc.exists()){
                     moduleJars.add(moduleSrc);
                     try {
-                        new ZipFile(moduleSrc).removeFile(relativeFilePath);
+                        ZipFile zipFile = new ZipFile(moduleSrc);
+                        FileHeader fileHeader = zipFile.getFileHeader(relativeFilePath);
+                        if(fileHeader != null){
+                            zipFile.removeFile(fileHeader);
+                        }
                     } catch (ZipException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
```

net.lingala.zip4j.exception.ZipException: could not find file header for file: iii/bbb/Copy of Foo.ceylon
    at net.lingala.zip4j.core.ZipFile.removeFile(ZipFile.java:791)
    at com.redhat.ceylon.eclipse.core.builder.CeylonBuilder.cleanRemovedFilesFromOutputs(CeylonBuilder.java:3232)
```

This happens when the user deletes a Ceylon source file that has never compiled, when the IDE tries to remove the source file from the src archive (but the source has never been added to the archive).
