### PR TITLE
ExpandTypeProposal.FindTypeVisitor: simplify visit

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ExpandTypeProposal.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ExpandTypeProposal.java
@@ -30,11 +30,12 @@ public class ExpandTypeProposal extends CorrectionProposal {
 
         @Override
         public void visit(Tree.Type that) {
-            super.visit(that);
+            // don't visit subtypes - we always want the complete type
             if (region.getOffset()>=that.getStartIndex() &&
                     region.getOffset()+region.getLength()<=that.getStopIndex()+1) {
                 result = that;
             }
+            // if the complete type doesn't match the region, the subtypes won't either
         }
     }
 


### PR DESCRIPTION
Since we always want to expand the complete type, there's no need to visit partial types of types.

(Note that this is an optimization, not a behavioral change; previously, if a subtype matched the selection, the result would later get overwritten by the complete type, because partial types lie within the start- and stopindex of the complete type.)

@gavinking: any complaints?
