### PR TITLE
make 'extract interface' detect 'assign' as variable

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/refactor/ExtractInterfaceRefactoring.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/refactor/ExtractInterfaceRefactoring.java
@@ -324,9 +324,14 @@ public class ExtractInterfaceRefactoring extends AbstractRefactoring {
                 content.append(toString(anonymousAnnotation)).append(delim).append(indent);
             }
             content.append("shared formal ");
+            if(member.getDeclarationModel().isVariable()){
+                content.append("variable ");
+            }
             for (Tree.Annotation annotation : annotationList.getAnnotations()) {
                 String annotationText = toString(annotation);
                 if (annotationText.equals("shared") ||
+                        annotationText.equals("variable") ||
+                        annotationText.equals("late") ||
                         annotationText.equals("default") ||
                         annotationText.equals("actual") ||
                         annotationText.equals("formal")) {


### PR DESCRIPTION
The current _extract interface_ does not detect that an attribute has an `assign` and does not add the `variable` annotation in the interface. This pull request fix this.
Plus, bonus track : skip `late` annotation for the interface if present in the implementation.
