### PR TITLE
Fix 'quick fix add attribute/function/class' for dynamic interfaces

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CreateProposal.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CreateProposal.java
@@ -31,6 +31,8 @@ import org.eclipse.text.edits.MultiTextEdit;
 import com.redhat.ceylon.compiler.typechecker.context.PhasedUnit;
 import com.redhat.ceylon.compiler.typechecker.model.ClassOrInterface;
 import com.redhat.ceylon.compiler.typechecker.model.Declaration;
+import com.redhat.ceylon.compiler.typechecker.model.Interface;
+import com.redhat.ceylon.compiler.typechecker.model.Class;
 import com.redhat.ceylon.compiler.typechecker.model.ProducedType;
 import com.redhat.ceylon.compiler.typechecker.model.Scope;
 import com.redhat.ceylon.compiler.typechecker.model.Unit;
@@ -115,9 +117,10 @@ class CreateProposal extends InitializerProposal {
                 offset = st.getStopIndex()+1;
             }
         }
-        String def = indentBefore + 
-                dg.generateShared(indent, delim) + 
-                indentAfter;
+        String generated = typeDec instanceof Interface ?
+            dg.generateSharedFormal(indent, delim) :
+            dg.generateShared(indent, delim);
+        String def = indentBefore + generated + indentAfter;
         int il = applyImports(change, dg.getImports(), 
                 unit.getCompilationUnit(), doc);
         change.addEdit(new InsertEdit(offset, def));
@@ -184,7 +187,8 @@ class CreateProposal extends InitializerProposal {
     static void addCreateMemberProposals(Collection<ICompletionProposal> proposals,
             IProject project, DefinitionGenerator dg, Declaration typeDec, 
             Tree.Statement statement) {
-        if (typeDec!=null && typeDec instanceof ClassOrInterface) {
+        if (typeDec!=null && (typeDec instanceof Class
+                || (typeDec instanceof Interface && dg.isFormalSupported()))) {
             for (PhasedUnit unit: getUnits(project)) {
                 if (typeDec.getUnit().equals(unit.getUnit())) {
                     //TODO: "object" declarations?

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/DefinitionGenerator.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/DefinitionGenerator.java
@@ -23,6 +23,8 @@ public abstract class DefinitionGenerator {
     
     abstract String generateShared(String indent, String delim);
     abstract String generate(String indent, String delim);
+    abstract String generateSharedFormal(String indent, String delim);
+    abstract boolean isFormalSupported();
     abstract Set<Declaration> getImports();
     abstract String getBrokenName();
     abstract String getDescription();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ObjectClassDefinitionGenerator.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ObjectClassDefinitionGenerator.java
@@ -39,12 +39,14 @@ import com.redhat.ceylon.compiler.typechecker.tree.Tree.MemberOrTypeExpression;
 class ObjectClassDefinitionGenerator extends DefinitionGenerator {
     
     private final String brokenName;
+    private final boolean isUpperCase;
     private final MemberOrTypeExpression node;
     private final CompilationUnit rootNode;
     private final String desc;
     private final Image image;
     private final ProducedType returnType;
     private final LinkedHashMap<String, ProducedType> parameters;
+   
 
     @Override
     String getBrokenName() {
@@ -89,6 +91,7 @@ class ObjectClassDefinitionGenerator extends DefinitionGenerator {
             ProducedType returnType,
             LinkedHashMap<String, ProducedType> paramTypes) {
         this.brokenName = brokenName;
+        this.isUpperCase = Character.isUpperCase(brokenName.charAt(0));
         this.node = node;
         this.rootNode = rootNode;
         this.desc = desc;
@@ -98,15 +101,25 @@ class ObjectClassDefinitionGenerator extends DefinitionGenerator {
     }
         
     String generateShared(String indent, String delim) {
-        return "shared " + generate(indent, delim);
+        return "shared " + generateInternal(indent, delim, false);
     }
     
     String generate(String indent, String delim) {
+        return generateInternal(indent, delim, false);
+    }
+    
+    String generateSharedFormal(String indent, String delim) {
+        return "shared formal "+ generateInternal(indent, delim, true);
+    }
+    
+    boolean isFormalSupported(){
+        return isClassGenerator();
+    }
+    
+    private String generateInternal(String indent, String delim, boolean isFormal) {
         StringBuffer def = new StringBuffer();
-        boolean isUpperCase = 
-                Character.isUpperCase(brokenName.charAt(0));
         boolean isVoid = returnType==null;
-        if (isUpperCase && parameters!=null) {
+        if (isClassGenerator()) {
             List<TypeParameter> typeParams = new ArrayList<TypeParameter>();
             StringBuilder typeParamDef = new StringBuilder();
             StringBuilder typeParamConstDef = new StringBuilder();
@@ -133,7 +146,7 @@ class ObjectClassDefinitionGenerator extends DefinitionGenerator {
             }
             def.append(indent).append("}");            
         }
-        else if (!isUpperCase && parameters==null) {
+        else if (isObjectGenerator()) {
             String defIndent = getDefaultIndent();
             String supertype = isVoid ? 
                     null : supertypeDeclaration(returnType);
@@ -152,6 +165,14 @@ class ObjectClassDefinitionGenerator extends DefinitionGenerator {
             return null;
         }
         return def.toString();
+    }
+    
+    private boolean isClassGenerator(){
+        return isUpperCase && parameters!=null;
+    }
+    
+    private boolean isObjectGenerator(){
+        return !isUpperCase && parameters==null;
     }
     
     Set<Declaration> getImports() {

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ValueFunctionDefinitionGenerator.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ValueFunctionDefinitionGenerator.java
@@ -92,10 +92,22 @@ class ValueFunctionDefinitionGenerator extends DefinitionGenerator {
     }
         
     String generateShared(String indent, String delim) {
-        return "shared " + generate(indent, delim);
+        return "shared " + generateInternal(indent, delim, false);
     }
-
+    
     String generate(String indent, String delim) {
+        return generateInternal(indent, delim, false);
+    }
+    
+    String generateSharedFormal(String indent, String delim) {
+        return "shared formal "+ generateInternal(indent, delim, true);
+    }
+    
+    boolean isFormalSupported(){
+        return true;
+    }
+    
+    private String generateInternal(String indent, String delim, boolean isFormal) {
         StringBuffer def = new StringBuffer();
         boolean isVoid = returnType==null;
         Unit unit = node.getUnit();
@@ -126,7 +138,10 @@ class ValueFunctionDefinitionGenerator extends DefinitionGenerator {
             .append(brokenName).append(typeParamDef);
             appendParameters(parameters, def);
             def.append(typeParamConstDef);
-            if (isVoid) {
+            if(isFormal){
+                def.append(";");
+            }
+            else if (isVoid) {
                 def.append(" {}");
             }
             else {
@@ -153,10 +168,12 @@ class ValueFunctionDefinitionGenerator extends DefinitionGenerator {
                 }
             }
             def.append(" ")
-            .append(brokenName)
-            .append(" = ")
-            .append(defaultValue(unit, returnType))
-            .append(";");
+               .append(brokenName);
+            if(!isFormal){
+                def.append(" = ")
+                   .append(defaultValue(unit, returnType));
+            }
+            def.append(";");
         }
         return def.toString();
     }


### PR DESCRIPTION
(Also includes fixes for regular interfaces)
## With this fix

For any type of interface (regular or dynamic) :
- quick fix 'add attribute/function/class' add **formal** attribute/function/class (instead of concrete before)
- quick fix 'add object' **deactivated**
## FTR Without this fix

For any type of interface (regular or dynamic) :
- add attribute was concrete : broken for regular and dynamic interfaces
- add function was concrete : broken for dynamic interface
- add class was concrete : broken for dynamic interface
- add object was activated : broken for regular and dynamic interfaces
