### PR TITLE
Possible fix for issue#1407

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ImportProposals.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ImportProposals.java
@@ -305,7 +305,7 @@ public class ImportProposals {
                                 .append(delim);
                         }
                     }
-                    sb.setLength(sb.length()-2);
+                    sb.setLength(sb.length()-1-delim.length());
                     sb.append(delim).append("}");
                     int start = imtl.getStartIndex();
                     int stop = imtl.getStopIndex();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ImportProposals.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ImportProposals.java
@@ -284,33 +284,11 @@ public class ImportProposals {
                 }
                 else {
                     //TODO: format it better!!!!
-                    StringBuilder sb = 
-                            new StringBuilder("{").append(delim);
-                    for (Tree.ImportMemberOrType imt: 
-                            imtl.getImportMemberOrTypes()) {
-                        Declaration dec = imt.getDeclarationModel();
-                        if (!set.contains(dec)) {
-                            sb.append(getDefaultIndent());
-                            if (imt.getAlias()!=null) {
-                                String alias = 
-                                        imt.getAlias()
-                                            .getIdentifier()
-                                            .getText();
-                                sb.append(alias).append('=');
-                            }
-                            String id = 
-                                    imt.getIdentifier()
-                                        .getText();
-                            sb.append(id).append(",")
-                                .append(delim);
-                        }
-                    }
-                    sb.setLength(sb.length()-1-delim.length());
-                    sb.append(delim).append("}");
-                    int start = imtl.getStartIndex();
-                    int stop = imtl.getStopIndex();
-                    result.add(new ReplaceEdit(start, stop-start+1, 
-                            sb.toString()));
+
+            		int start = imtl.getStartIndex();
+            		int stop = imtl.getStopIndex();
+            		String formattedImport = formatImportMembers(delim, getDefaultIndent(), set, imtl);
+            		result.add(new ReplaceEdit(start, stop-start+1, formattedImport));
                 }
             }
         }
@@ -351,6 +329,34 @@ public class ImportProposals {
         }
         return result;
     }
+
+	public static String formatImportMembers(String delim, String indent, Set<Declaration> set,
+			Tree.ImportMemberOrTypeList imtl) {
+		StringBuilder sb = 
+		        new StringBuilder("{").append(delim);
+		for (Tree.ImportMemberOrType imt: 
+		        imtl.getImportMemberOrTypes()) {
+		    Declaration dec = imt.getDeclarationModel();
+		    if (!set.contains(dec)) {
+		        sb.append(indent);
+		        if (imt.getAlias()!=null) {
+		            String alias = 
+		                    imt.getAlias()
+		                        .getIdentifier()
+		                        .getText();
+		            sb.append(alias).append('=');
+		        }
+		        String id = 
+		                imt.getIdentifier()
+		                    .getText();
+		        sb.append(id).append(",")
+		            .append(delim);
+		    }
+		}
+		sb.setLength(sb.length()-1-delim.length());
+		sb.append(delim).append("}");
+		return sb.toString();
+	}
     
     public static int getBestImportInsertPosition(
             Tree.CompilationUnit cu) {

--- a/tests/com.redhat.ceylon.eclipse.ui.test/src/com/redhat/ceylon/eclipse/ui/test/headless/ImportProposalTests.java
+++ b/tests/com.redhat.ceylon.eclipse.ui.test/src/com/redhat/ceylon/eclipse/ui/test/headless/ImportProposalTests.java
@@ -1,0 +1,69 @@
+package com.redhat.ceylon.eclipse.ui.test.headless;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.antlr.runtime.CommonToken;
+import org.junit.Test;
+
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.Identifier;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.ImportMemberOrType;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.ImportMemberOrTypeList;
+import com.redhat.ceylon.eclipse.code.correct.ImportProposals;
+import com.redhat.ceylon.model.typechecker.model.Declaration;
+
+public class ImportProposalTests {
+    @Test
+    public void testDelimiter1() {
+    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
+		
+		String result = ImportProposals.formatImportMembers("\n", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{\n  Bar,\n  Foo\n}");
+		
+	}
+    
+    @Test
+    public void testDelimiter2() {
+    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
+		
+		String result = ImportProposals.formatImportMembers("\r\n", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{\r\n  Bar,\r\n  Foo\r\n}");
+	}
+
+    @Test
+    public void testDelimiter3() {
+    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
+		
+		String result = ImportProposals.formatImportMembers("|||", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{|||  Bar,|||  Foo|||}");
+	}
+
+	private ImportMemberOrTypeList prepareImportMemberOrTypeList() {
+		CommonToken noToken = new CommonToken(0);
+		ImportMemberOrTypeList imtl = new ImportMemberOrTypeList(noToken);
+    	List<ImportMemberOrType> importMembers = imtl.getImportMemberOrTypes();
+    	
+    	ImportMemberOrType importMember = new ImportMemberOrType(noToken);
+    	importMember.setAlias(null);
+    	importMember.setText("Bar");
+    	Identifier identifier = new Identifier(noToken);
+    	identifier.setText("Bar");
+		importMember.setIdentifier(identifier);
+    	importMembers.add(importMember);
+    	
+    	importMember = new ImportMemberOrType(noToken);
+    	importMember.setAlias(null);
+    	importMember.setText("Foo");
+    	identifier = new Identifier(noToken);
+    	identifier.setText("Foo");
+		importMember.setIdentifier(identifier);
+    	importMembers.add(importMember);
+		return imtl;
+	}
+
+}

--- a/tests/com.redhat.ceylon.eclipse.ui.test/src/com/redhat/ceylon/eclipse/ui/test/headless/ImportProposalTests.java
+++ b/tests/com.redhat.ceylon.eclipse.ui.test/src/com/redhat/ceylon/eclipse/ui/test/headless/ImportProposalTests.java
@@ -45,30 +45,30 @@ public class ImportProposalTests {
     
     @Test
     public void testSingleImport1() {
-    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+    	ImportMemberOrTypeList imtl = prepareSingleImportMemberOrTypeList();
 		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
 		
 		String result = ImportProposals.formatImportMembers("\r\n", "  ", ignoredDeclarations, imtl);
-		assertEquals(result, "{\r\n  Bar");
+		assertEquals(result, "{\r\n  Bar\r\n}");
 	}
     
     @Test
     public void testSingleImport2() {
-    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+    	ImportMemberOrTypeList imtl = prepareSingleImportMemberOrTypeList();
 		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
 		
-		String result = ImportProposals.formatImportMembers("\r\n", "  ", ignoredDeclarations, imtl);
-		assertEquals(result, "{\n  Bar}");
+		String result = ImportProposals.formatImportMembers("\n", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{\n  Bar\n}");
 	}
 
 
     @Test
     public void testSingleImport3() {
-    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+    	ImportMemberOrTypeList imtl = prepareSingleImportMemberOrTypeList();
 		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
 		
 		String result = ImportProposals.formatImportMembers("|||", "  ", ignoredDeclarations, imtl);
-		assertEquals(result, "{|||  Bar}");
+		assertEquals(result, "{|||  Bar|||}");
 	}
     
 	private ImportMemberOrTypeList prepareSingleImportMemberOrTypeList() {

--- a/tests/com.redhat.ceylon.eclipse.ui.test/src/com/redhat/ceylon/eclipse/ui/test/headless/ImportProposalTests.java
+++ b/tests/com.redhat.ceylon.eclipse.ui.test/src/com/redhat/ceylon/eclipse/ui/test/headless/ImportProposalTests.java
@@ -42,6 +42,50 @@ public class ImportProposalTests {
 		String result = ImportProposals.formatImportMembers("|||", "  ", ignoredDeclarations, imtl);
 		assertEquals(result, "{|||  Bar,|||  Foo|||}");
 	}
+    
+    @Test
+    public void testSingleImport1() {
+    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
+		
+		String result = ImportProposals.formatImportMembers("\r\n", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{\r\n  Bar");
+	}
+    
+    @Test
+    public void testSingleImport2() {
+    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
+		
+		String result = ImportProposals.formatImportMembers("\r\n", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{\n  Bar}");
+	}
+
+
+    @Test
+    public void testSingleImport3() {
+    	ImportMemberOrTypeList imtl = prepareImportMemberOrTypeList();
+		HashSet<Declaration> ignoredDeclarations = new HashSet<Declaration>();
+		
+		String result = ImportProposals.formatImportMembers("|||", "  ", ignoredDeclarations, imtl);
+		assertEquals(result, "{|||  Bar}");
+	}
+    
+	private ImportMemberOrTypeList prepareSingleImportMemberOrTypeList() {
+		CommonToken noToken = new CommonToken(0);
+		ImportMemberOrTypeList imtl = new ImportMemberOrTypeList(noToken);
+    	List<ImportMemberOrType> importMembers = imtl.getImportMemberOrTypes();
+    	
+    	ImportMemberOrType importMember = new ImportMemberOrType(noToken);
+    	importMember.setAlias(null);
+    	importMember.setText("Bar");
+    	Identifier identifier = new Identifier(noToken);
+    	identifier.setText("Bar");
+		importMember.setIdentifier(identifier);
+    	importMembers.add(importMember);
+    	
+		return imtl;
+	}
 
 	private ImportMemberOrTypeList prepareImportMemberOrTypeList() {
 		CommonToken noToken = new CommonToken(0);


### PR DESCRIPTION
The problem is caused by the fact that Windows has two characters for linebreaks.
In Linux: ",\n" turns into ""
Under Windows ",\r\n" turns into "," where the comma is still trailing.
This pullrequest should be able to fix #1407 if I haven't overlooked anything.