### PR TITLE
Fix #1443

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/source/com/redhat/ceylon/eclipse/code/refactor/EclipseAbstractRefactoring.ceylon
+++ b/plugins/com.redhat.ceylon.eclipse.ui/source/com/redhat/ceylon/eclipse/code/refactor/EclipseAbstractRefactoring.ceylon
@@ -74,7 +74,7 @@ abstract class EclipseAbstractRefactoring(IEditorPart editorPart) extends Refact
         if (exists existingRootNode=rootNode,
             is IFileEditorInput input = editorPart.editorInput) {
             sourceVirtualFile = if (exists file=EditorUtil.getFile(input)) then IFileVirtualFile(file) else null;
-            node = Nodes.findNode(rootNode, EditorUtil.getSelection(editorPart));
+            node = Nodes.findNode(rootNode, tokens, EditorUtil.getSelection(editorPart));
         } else {
             sourceVirtualFile = null;
             node = null;

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/complete/CeylonCompletionProcessor.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/complete/CeylonCompletionProcessor.java
@@ -725,13 +725,13 @@ public class CeylonCompletionProcessor implements IContentAssistProcessor {
             int adjustedStart, int adjustedEnd,
             int tokenType, Tree.CompilationUnit rootNode, 
             int offset) {
-        Node node = findNode(rootNode, 
+        Node node = findNode(rootNode, null, 
                 adjustedStart, adjustedEnd);
         if (node instanceof Tree.StringLiteral) {
             Tree.StringLiteral sl = 
                     (Tree.StringLiteral) node;
             if (!sl.getDocLinks().isEmpty()) {
-                node = findNode(node, offset, offset);
+                node = findNode(node, null, offset, offset);
             }
         }
         if (tokenType==RBRACE && 

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/AddConstructorHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/AddConstructorHandler.java
@@ -38,7 +38,7 @@ public class AddConstructorHandler extends AbstractHandler {
                 int start = selection.getOffset();
                 int end = start + selection.getLength();
                 Node node = findDeclarationWithBody(rootNode, 
-                        findNode(rootNode, start, end));
+                        findNode(rootNode, ce.getParseController().getTokens(), start, end));
                 List<ICompletionProposal> list = 
                         new ArrayList<ICompletionProposal>();
                 addConstructorProposal(getFile(editor), list, node, rootNode);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/AddParameterListHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/AddParameterListHandler.java
@@ -38,7 +38,7 @@ public class AddParameterListHandler extends AbstractHandler {
                 int start = selection.getOffset();
                 int end = start + selection.getLength();
                 Node node = findDeclarationWithBody(rootNode, 
-                        findNode(rootNode, start, end));
+                        findNode(rootNode, ce.getParseController().getTokens(), start, end));
                 List<ICompletionProposal> list = 
                         new ArrayList<ICompletionProposal>();
                 addParameterListProposal(getFile(editor), list, node, rootNode);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/AssignToLocalHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/AssignToLocalHandler.java
@@ -33,7 +33,7 @@ public class AssignToLocalHandler extends AbstractHandler {
                 IRegion selection = ce.getSelection();
                 int start = selection.getOffset();
                 int end = start + selection.getLength();
-                Node node = findNode(rootNode, start, end);
+                Node node = findNode(rootNode, ce.getParseController().getTokens(), start, end);
                 List<ICompletionProposal> list = 
                         new ArrayList<ICompletionProposal>();
                 addAssignToLocalProposal((CeylonEditor)editor, rootNode, list, node, start);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CeylonCorrectionProcessor.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/CeylonCorrectionProcessor.java
@@ -483,7 +483,7 @@ public class CeylonCorrectionProcessor extends QuickAssistAssistant
         //this method never gets called :-/
         /*Tree.CompilationUnit cu = (CompilationUnit) context.getModel()
                 .getAST(new NullMessageHandler(), new NullProgressMonitor());
-        return CeylonSourcePositionLocator.findNode(cu, context.getOffset(), 
+        return CeylonSourcePositionLocator.findNode(cu, null, context.getOffset(), 
                 context.getOffset()+context.getLength()) instanceof Tree.Term;*/
         return true;
     }
@@ -508,7 +508,7 @@ public class CeylonCorrectionProcessor extends QuickAssistAssistant
         TypeChecker tc = getProjectTypeChecker(project);
         int start = problem.getOffset();
         int end = start + problem.getLength();
-        Node node = findNode(rootNode, start, end);
+        Node node = findNode(rootNode, null, start, end);
         switch (problem.getProblemId()) {
         case 100:
             addDeclareLocalProposal(rootNode, node, proposals, file, editor);
@@ -990,7 +990,7 @@ public class CeylonCorrectionProcessor extends QuickAssistAssistant
         if (rootNode!=null) {
             int start = context.getOffset();
             int end = start + context.getLength();
-            Node node = findNode(rootNode, start, end);
+            Node node = findNode(rootNode, editor.getParseController().getTokens(), start, end);
             int currentOffset = editor.getSelection().getOffset();
             
             RenameProposal.add(proposals, editor);
@@ -1353,7 +1353,7 @@ public class CeylonCorrectionProcessor extends QuickAssistAssistant
         if (annotation.getSeverity()==IMarker.SEVERITY_WARNING) {
             Tree.CompilationUnit rootNode = getRootNode();
             Tree.Statement st = Nodes.findStatement(rootNode,
-                    Nodes.findNode(rootNode, location.getOffset(), 
+                    Nodes.findNode(rootNode, null, location.getOffset(), 
                             location.getOffset()+location.getLength()));
             if (st==null) return;
             if (!(st instanceof Tree.Declaration)) {

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ConvertIfElseToThenElse.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/ConvertIfElseToThenElse.java
@@ -237,7 +237,7 @@ class ConvertIfElseToThenElse extends CorrectionProposal {
                 Matcher m = Pattern.compile("(\\s*)\\w+").matcher(prevLine);
                 if (m.find()) {
                     int whitespaceLen = m.group(1).length();
-                    Node node = Nodes.findNode(cu, lineInfo.getOffset() + whitespaceLen, 
+                    Node node = Nodes.findNode(cu, null, lineInfo.getOffset() + whitespaceLen, 
                             lineInfo.getOffset() + whitespaceLen + 1);
                     return Nodes.findStatement(cu, node);
                 }

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/DestructureHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/DestructureHandler.java
@@ -32,7 +32,8 @@ public class DestructureHandler extends AbstractHandler {
                 IRegion selection = ce.getSelection();
                 int start = selection.getOffset();
                 int end = start + selection.getLength();
-                Node node = findNode(rootNode, start, end);
+                Node node = findNode(rootNode, ce.getParseController().getTokens(), 
+                        start, end);
                 List<ICompletionProposal> list = 
                         new ArrayList<ICompletionProposal>();
                 DestructureProposal.addDestructureProposal(ce, rootNode, list, node, start);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/PrintHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/PrintHandler.java
@@ -35,7 +35,7 @@ public class PrintHandler extends AbstractHandler {
                 IRegion selection = ce.getSelection();
                 int start = selection.getOffset();
                 int end = start + selection.getLength();
-                Node node = findNode(rootNode, start, end);
+                Node node = findNode(rootNode, ce.getParseController().getTokens(), start, end);
                 List<ICompletionProposal> list = 
                         new ArrayList<ICompletionProposal>();
                 addPrintProposal(rootNode, list, node, start);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/RefineFormalMembersHandler.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/correct/RefineFormalMembersHandler.java
@@ -33,7 +33,7 @@ public class RefineFormalMembersHandler extends AbstractHandler {
                 IRegion selection = ce.getSelection();
                 int start = selection.getOffset();
                 int end = start + selection.getLength();
-                Node node = findNode(rootNode, start, end);
+                Node node = findNode(rootNode, ce.getParseController().getTokens(), start, end);
                 List<ICompletionProposal> list = 
                         new ArrayList<ICompletionProposal>();
                 addRefineFormalMembersProposal(list, node, rootNode, false);

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/CeylonEditor.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/CeylonEditor.java
@@ -2240,6 +2240,7 @@ public class CeylonEditor extends TextEditor implements ICeylonModelListener {
         }
         else {
             return findNode(cpc.getRootNode(), 
+                    cpc.getTokens(), 
                     EditorUtil.getSelection(this));
         }
     }

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/FormatAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/FormatAction.java
@@ -95,7 +95,7 @@ final class FormatAction extends Action {
         boolean formatAll = !selected || document.getLength()==ts.getLength();
         if (!formatAll) {
             // a node was selected, format only that
-            Node selectedRootNode = Nodes.findNode(pc.getRootNode(), ts);
+            Node selectedRootNode = Nodes.findNode(pc.getRootNode(), pc.getTokens(), ts);
             if (selectedRootNode == null)
                 return;
             if (selectedRootNode instanceof Body || selectedRootNode instanceof CompilationUnit) {

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/MarkOccurrencesAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/MarkOccurrencesAction.java
@@ -235,8 +235,11 @@ public class MarkOccurrencesAction
             // a parse error
             return;
         }
+        List<CommonToken> tokens = activeEditor != null ?
+            activeEditor.getParseController().getTokens() :
+            null;
         Node selectedNode = 
-                findNode(root, offset, offset+length-1);
+            findNode(root, tokens, offset, offset+length-1);
         try {
             List<Node> declarations = 
                     getDeclarationsOf(parseController, 

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/PeekDefinitionPopup.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/PeekDefinitionPopup.java
@@ -324,6 +324,7 @@ final class PeekDefinitionPopup extends PopupDialog
                 controller.getRootNode();
         referencedNode = 
                 getReferencedNode(findNode(rootNode, 
+                        controller.getTokens(), 
                         offset, offset+length));
         if (referencedNode==null) return;
         IProject project = controller.getProject();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/TargetNavigationAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/TargetNavigationAction.java
@@ -45,6 +45,7 @@ abstract class TargetNavigationAction extends Action {
         CeylonParseController pc = fEditor.getParseController();
         Object curNode = 
                 findNode(pc.getRootNode(), 
+                        pc.getTokens(), 
                         selection.getOffset(), 
                         selection.getOffset() + selection.getLength() - 1);
         if (curNode == null || selection.getOffset() == 0) {

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/DocumentationHover.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/DocumentationHover.java
@@ -594,6 +594,7 @@ public class DocumentationHover extends SourceInfoHover {
                 int length = selection.getLength();
                 if (offset<=hoffset && offset+length>=hoffset) {
                     Node node = findNode(rootNode, 
+                            parseController.getTokens(), 
                             offset, offset+length-1);
                     IDocument document = 
                             editor.getCeylonSourceViewer()

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/SourceViewerInformationControl.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/SourceViewerInformationControl.java
@@ -551,6 +551,7 @@ public class SourceViewerInformationControl
                 controller.getRootNode();
         referencedNode = 
                 getReferencedNode(findNode(rootNode, 
+                        controller.getTokens(), 
                         offset, offset+length));
         if (referencedNode==null) return;
         IProject project = controller.getProject();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/refactor/AbstractRefactoring.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/refactor/AbstractRefactoring.java
@@ -67,7 +67,7 @@ abstract class AbstractRefactoring extends Refactoring {
             IEditorInput input = editor.getEditorInput();
             if (rootNode!=null && input instanceof IFileEditorInput) {
                 sourceFile = EditorUtil.getFile(input);
-                node = findNode(rootNode, getSelection(ce));
+                node = findNode(rootNode, tokens, getSelection(ce));
             }
             else {
                 sourceFile = null;

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/resolve/CeylonHyperlinkDetector.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/resolve/CeylonHyperlinkDetector.java
@@ -86,6 +86,7 @@ public class CeylonHyperlinkDetector implements IHyperlinkDetector {
         else {
             Node node = 
                     findNode(controller.getRootNode(), 
+                            controller.getTokens(), 
                             region.getOffset(), 
                             region.getOffset()+region.getLength());
             if (node==null) {

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/resolve/JavaHyperlinkDetector.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/resolve/JavaHyperlinkDetector.java
@@ -90,6 +90,7 @@ public class JavaHyperlinkDetector implements IHyperlinkDetector {
         else {
             Node node = 
                     findNode(pc.getRootNode(), 
+                            pc.getTokens(), 
                             region.getOffset(), 
                             region.getOffset()+region.getLength());
             if (node==null) {

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/search/AbstractFindAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/search/AbstractFindAction.java
@@ -48,7 +48,7 @@ abstract class AbstractFindAction extends Action implements IObjectActionDelegat
             if (element.getVirtualFile() != null) {
                 CeylonUnit unit = getUnit(element.getVirtualFile());
                 Tree.CompilationUnit rn = unit.getCompilationUnit();
-                Node node = findNode(rn, element.getStartOffset(), 
+                Node node = findNode(rn, null, element.getStartOffset(), 
                         element.getEndOffset());
                 if (node instanceof Tree.Declaration) {
                     declaration = ((Tree.Declaration) node).getDeclarationModel();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/launch/CeylonApplicationLaunchShortcut.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/launch/CeylonApplicationLaunchShortcut.java
@@ -129,7 +129,7 @@ public class CeylonApplicationLaunchShortcut implements ILaunchShortcut {
                 if (cu!=null) {
                     ISelection selection = ce.getSelectionProvider().getSelection();
                     if (selection instanceof ITextSelection) {
-                        Node node = Nodes.findToplevelStatement(cu, Nodes.findNode(cu, (ITextSelection) selection));
+                        Node node = Nodes.findToplevelStatement(cu, Nodes.findNode(cu, cpc.getTokens(), (ITextSelection) selection));
                         if (node instanceof Tree.AnyMethod) {
                             Function method = ((Tree.AnyMethod) node).getDeclarationModel();
                             if (method.isToplevel() && 

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/launch/CeylonModuleLaunchShortcut.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/core/launch/CeylonModuleLaunchShortcut.java
@@ -241,7 +241,7 @@ public abstract class CeylonModuleLaunchShortcut implements ILaunchShortcut2 {
                     ISelection selection = ce.getSelectionProvider().getSelection();
                     if (selection instanceof ITextSelection) {
                         Node node = Nodes.findToplevelStatement(cu, 
-                                Nodes.findNode(cu, (ITextSelection) selection));
+                                Nodes.findNode(cu, cpc.getTokens(), (ITextSelection) selection));
                         if (node instanceof Tree.AnyMethod) {
                             Function method = 
                                     ((Tree.AnyMethod) node).getDeclarationModel();
@@ -348,7 +348,7 @@ public abstract class CeylonModuleLaunchShortcut implements ILaunchShortcut2 {
                 if (cu!=null) {
                     ITextSelection selection = ce.getSelectionFromThread();
                     Node node = Nodes.findToplevelStatement(cu, 
-                            Nodes.findNode(cu,selection));
+                            Nodes.findNode(cu,cpc.getTokens(),selection));
                     if (node instanceof Tree.AnyMethod) {
                         Function method = 
                                 ((Tree.AnyMethod) node).getDeclarationModel();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/util/Nodes.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/util/Nodes.java
@@ -82,12 +82,13 @@ public class Nodes {
     }
 
     public static Node findNode(Tree.CompilationUnit cu, int offset) {
-        return findNode(cu, offset, offset+1);
+        return findNode(cu, null, offset, offset+1);
     }
 
     public static Node findNode(Node node, 
+            List<CommonToken> tokens, 
             int startOffset, int endOffset) {
-        return delegate.findNode(node, startOffset, endOffset);
+        return delegate.findNode(node, tokens, startOffset, endOffset);
     }
 
     private static Node findScope(Tree.CompilationUnit cu, 
@@ -96,8 +97,10 @@ public class Nodes {
     }
 
     public static Node findNode(Tree.CompilationUnit cu, 
+            List<CommonToken> tokens, 
             ITextSelection s) {
         return findNode(cu, 
+                tokens, 
                 s.getOffset(), 
                 s.getOffset()+s.getLength());
     }


### PR DESCRIPTION
findNode() now takes an additional token list (see ceylon/ceylon-ide-common@5d509a0 for details), which we have to pass in lots of places. Most of the time, we can get it from the CeylonParseController; occasionally, we just pass null. (That's not necessarily bad: for example, we don't have to worry about whitespace in the selection when the selection comes from an error marker.)

This is a lot of changes in code that has nothing to do with me, so I don’t want to just push it to master.