### PR TITLE
Improve formatter error reporting

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/FormatAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/FormatAction.java
@@ -208,12 +208,10 @@ final class FormatAction extends Action {
                 }
             }
         } catch (Exception e) {
-            CeylonPlugin.log(IStatus.ERROR, "Error during code formatting");
-            e.printStackTrace();
+            CeylonPlugin.log(IStatus.ERROR, "Error during code formatting", e);
             return;
         } catch (AssertionError e) {
-            CeylonPlugin.log(IStatus.ERROR, "Error during code formatting");
-            e.printStackTrace();
+            CeylonPlugin.log(IStatus.ERROR, "Error during code formatting", e);
             return;
         }
         

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/ui/CeylonPlugin.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/ui/CeylonPlugin.java
@@ -609,6 +609,12 @@ public class CeylonPlugin extends AbstractUIPlugin implements CeylonResources {
         getInstance().getLog().log(status);
     }
 
+    public static void log(int severity, String message, Throwable cause) {
+        Status status =
+            new Status(severity, PLUGIN_ID, message, cause);
+        getInstance().getLog().log(status);
+    }
+
     private static Font getFont(final String pref) {
         class GetFont implements Runnable {
             public Font result;


### PR DESCRIPTION
This adds an overload to CeylonPlugin.log() that accepts a Throwable, so that we can report errors caused by exceptions properly.

CC @bjansen