### PR TITLE
Fix calls to findNode()

### DIFF
--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/MarkOccurrencesAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/MarkOccurrencesAction.java
@@ -239,7 +239,7 @@ public class MarkOccurrencesAction
             activeEditor.getParseController().getTokens() :
             null;
         Node selectedNode = 
-            findNode(root, tokens, offset, offset+length-1);
+            findNode(root, tokens, offset, offset+length);
         try {
             List<Node> declarations = 
                     getDeclarationsOf(parseController, 

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/TargetNavigationAction.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/editor/TargetNavigationAction.java
@@ -47,7 +47,7 @@ abstract class TargetNavigationAction extends Action {
                 findNode(pc.getRootNode(), 
                         pc.getTokens(), 
                         selection.getOffset(), 
-                        selection.getOffset() + selection.getLength() - 1);
+                        selection.getOffset() + selection.getLength());
         if (curNode == null || selection.getOffset() == 0) {
             curNode= pc.getRootNode();
         }

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/DocumentationHover.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/hover/DocumentationHover.java
@@ -355,7 +355,7 @@ public class DocumentationHover extends SourceInfoHover {
                 if (offset<=hoffset && offset+length>=hoffset) {
                     Node node = findNode(rootNode, 
                             parseController.getTokens(), 
-                            offset, offset+length-1);
+                            offset, offset+length);
                     IDocument document = 
                             editor.getCeylonSourceViewer()
                                     .getDocument();

--- a/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/outline/HierarchyView.java
+++ b/plugins/com.redhat.ceylon.eclipse.ui/src/com/redhat/ceylon/eclipse/code/outline/HierarchyView.java
@@ -976,6 +976,7 @@ public class HierarchyView extends ViewPart {
         CeylonParseController cpc = 
                 editor.getParseController();
         Node node = findNode(cpc.getRootNode(), 
+                // TODO shouldn't we search for the entire selection?
                 editor.getSelection().getOffset());
         Referenceable dec = getReferencedDeclaration(node);
         if (dec instanceof Declaration) {


### PR DESCRIPTION
The `endOffset` argument to `findNode()` used to be undocumented, and so a few places erroneously called it with `start+length-1` instead of `start+length`.

---

I wasn’t able to find out what triggers `TargetNavigationAction`, so I only tested `MarkOccurrencesAction` and `DocumentationHover`.

#### `MarkOccurrencesAction`

Previously, if you selected `print(` in `print("foo")`, occurrences of `print` still got marked. With the fix, they only get marked if you select parts of `print` proper (may include whitespace around `print`, if there is any, due to the recent improvement in `FindNodesVisitor`). If you include the parenthesis in the selection, no marks for you.

#### `DocumentationHover`

I couldn’t find a change. If you select `rint(`, you still get the documentation for `print`. If you select `print` or `print(`, however, or if you hover over the first character, then you just get a generic “Expression of type `Anything(Anything)`. Must be an off-by-one error elsewhere.