### PR TITLE
Fixed ceylon-sdk build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ separately:
    `.../ceylon/dist/osgi/build/dist`
 
 2. Build the Ceylon SDK locally  (see [here][sdk] for more details):
-   - In the `.../ceylon` directory run: `ant clean-sdk sdk`
+   - In the `.../ceylon-sdk` directory run: `ant clean publish`
    - This should have produced an eclipse update site at the following path:
    
    `.../ceylon-sdk/osgi/dist`


### PR DESCRIPTION
It appears instructions outlining how to build sdk were outdated.